### PR TITLE
Auth & Name Patch

### DIFF
--- a/Server/Utilities/helpers.js
+++ b/Server/Utilities/helpers.js
@@ -519,6 +519,7 @@ var createToken = exports.createToken = function(req, res, next, authenticateTyp
       expiration: calculateTokenExpiration(),
       session: user.session
     }, process.env.TOKEN_SECRET || authConfig.tokenSecret);
+    res.setHeader('Access-Control-Allow-Origin','*');
     res.json({access_token: token});
   })(req, res, next);
 };

--- a/Server/Utilities/requestHandlers.js
+++ b/Server/Utilities/requestHandlers.js
@@ -73,6 +73,7 @@ exports.logoutHandler = function(req, res, next) {
         console.error(err);
         return;
       }
+      res.setHeader('Access-Control-Allow-Origin','*');
       res.sendStatus(200);
     });
   })(req, res, next);

--- a/Server/app.js
+++ b/Server/app.js
@@ -16,6 +16,15 @@ var strategyUtil = require('./Utilities/strategyUtil');
 
 var app = express();
 
+// TODO: fit this in better, CORS for POSTing
+app.options('/*', function(req,res) {
+  res.set({
+    'Access-Control-Allow-Headers':'Content-Type',
+    'Access-Control-Allow-Origin':'*',
+  });
+  res.end();
+});
+
 // view engine setup
 //app.set('views', path.join(__dirname, 'views'));
 //app.set('view engine', 'jade');
@@ -74,14 +83,6 @@ app.post('/editEntry', handlers.checkTokenHandler, handlers.editEntry);
 
 //NOTE: figure out best practices for above route
 
-// TODO: fit this in better, CORS for POSTing
-app.options('/*', function(req,res) {
-  res.set({
-    'Access-Control-Allow-Headers':'Content-Type',
-    'Access-Control-Allow-Origin':'*',
-  });
-  res.end();
-});
 
 app.use(function(req, res, next) {
   var err = new Error('Not Found');

--- a/blueprints/angular-plain/content/refCardCode.js
+++ b/blueprints/angular-plain/content/refCardCode.js
@@ -131,10 +131,23 @@ angular.module('sodocan')
   };
 
   // we only work with top entries, so only need the functionName
-  $scope.upvote = function(item) {
-    sodocanAPI.upvote(sodocanAPI.docs[item].explanations[$scope.EntryType][0].entryID,item,$scope.EntryType,postResp);
-    // cheat to update number
-    sodocanAPI.docs[item].explanations[$scope.EntryType][0].upvotes++;
+  $scope.upvote = function(item,comment) {
+    if (!comment) {
+      sodocanAPI.upvote(sodocanAPI.docs[item].explanations[$scope.EntryType][0].entryID,
+                        item,
+                        $scope.EntryType,
+                        postResp);
+      // cheat to update number
+      sodocanAPI.docs[item].explanations[$scope.EntryType][0].upvotes++;
+    } else {
+      sodocanAPI.upvote(sodocanAPI.docs[item].explanations[$scope.EntryType][0].entryID,
+                        item,
+                        $scope.EntryType,
+                        comment.commentID,
+                        postResp);
+      // optimistic cheating here too
+      comment.upvotes++;
+    }
   };
 
 }]);

--- a/blueprints/angular-plain/content/refCardTpl.html
+++ b/blueprints/angular-plain/content/refCardTpl.html
@@ -23,8 +23,9 @@
     </form>
   </div>
   <div style="background:#ccc">
-    <div style="border-top: 2px solid #eee;padding: 5px" ng-repeat="comment in docs[item].explanations[EntryType][0].additions">
+    <div style="border-top: 2px solid #eee;padding: 5px" ng-repeat="comment in docs[item].explanations[EntryType][0].comments">
       {{comment.text}}
+      <span ng-click="upvote(item,comment)" style="float:right">Upvote: {{comment.upvotes}}</span>
     </div>
   </div>
   <a ng-click="changeCard('comments',item)" href="{{item}}/1/-1">Load Comments</a>

--- a/blueprints/angular-plain/header/headerCode.js
+++ b/blueprints/angular-plain/header/headerCode.js
@@ -14,6 +14,34 @@ angular.module('sodocan')
   $scope.display = sodocanAPI.projectName;
 
   $scope.test = function() {
+
+    if (window.localStorage.getItem('sodocanToken')) {
+      sodocanAPI.logout(function(err,resp) {
+        if (err) console.log('__ERR');
+        console.log(err);
+        console.log(resp);
+      });
+    } else {
+      sodocanAPI.login('Harold','lept0n',function(err,resp) {
+        if (err) {
+          console.log('___ERROR:');
+          console.log(err);
+          return;
+        }
+
+        console.log('___LOGGED IN:');
+        console.log(resp);
+      });
+    }
+    /*
+     * register example:
+     *
+     * sodocanAPI.register('Harold','lept0n',function(err,resp) {});
+     */
+
+    /* upvoting test
+     *
+
     var upvoter,addID;
     var refObj = {
       //ref: 'Ctor',
@@ -39,5 +67,6 @@ angular.module('sodocan')
         });
       });
     });
+    */
   };
 }]);

--- a/serve.js
+++ b/serve.js
@@ -97,9 +97,9 @@ function handleRequest(req,res) {
   }
   var filePath = DIR+req.url;
   
-  var pos = filePath.search(/underscore/);
+  var pos = filePath.search(/fakeUnderscore/);
   if (pos>-1) {
-    var path = filePath.substr(pos+10);
+    var path = filePath.substr(pos+14);
     filePath = DIR+'/'+path;
   };
 


### PR DESCRIPTION
- Virtually no changes, sodocanAPI now features
  - API.login(user,pass,cb)
  - API.register(user,pass,cb)
  - API.logout(cb)
- Token is available at sodocanAPI.authToken & localStorage.sodocanToken
- Automatically added to requests (no need to change your code)

Crude example of login/logout/register in headerCode (ng-click) ctrler.
No Github integration and not heavily tested.
